### PR TITLE
Added as_bytes() function for ecdsa VerifyKey

### DIFF
--- a/src/signature/ecdsa/verify_key.rs
+++ b/src/signature/ecdsa/verify_key.rs
@@ -41,6 +41,11 @@ where
 
         point_result.map(VerifyKey).map_err(|_| Error::new())
     }
+
+    /// Get byte slice of inner encoded point
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
 }
 
 impl<C: Curve> Verifier<Signature<C>> for VerifyKey<C>


### PR DESCRIPTION
I really needed a way to get the public key back out in SEC1 encoding for exporting. I think it's pretty useful.

Please let me know if there is a better way to do this.