### PR TITLE
v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2020-12-11)
+### Added
+- `ecdsa::VerifyKey::as_bytes()` function ([#21])
+
+[#21]: https://github.com/RustCrypto/ring-compat/pull/21
+
 ## 0.1.0 (2020-10-09)
 ### Added
 - Signature support: ECDSA and Ed25519 ([#17])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "ring-compat"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aead",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-compat"
-version = "0.1.0"
+version = "0.1.1"
 description = """
 Compatibility crate for using RustCrypto's traits with the cryptographic
 algorithm implementations from *ring*


### PR DESCRIPTION
### Added
- `ecdsa::VerifyKey::as_bytes()` function ([#21])

[#21]: https://github.com/RustCrypto/ring-compat/pull/21