### PR TITLE
Add 'std' feature that enables digest/std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ digest = { version = "0.9", features = ["dev"] }
 default = ["aead", "alloc", "digest", "signature"]
 alloc = ["aead/alloc"]
 signature = ["ecdsa", "ed25519", "p256", "p384"]
+std = ["digest/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ digest = { version = "0.9", features = ["dev"] }
 default = ["aead", "alloc", "digest", "signature"]
 alloc = ["aead/alloc"]
 signature = ["ecdsa", "ed25519", "p256", "p384"]
-std = ["digest/std"]
+std = ["digest/std", "ecdsa/std", "ed25519/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 #[cfg(feature = "aead")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aead")))]
 pub mod aead;


### PR DESCRIPTION
This enables using digest's std::io::Write support (the impl_write! macro) with ring-compat's digest implementations.

The sha2 crate already does the same thing -- I found that my code (which uses Write) using sha2's Sha256 was failing to compile on ring-compat's Sha256