### PR TITLE
Bump `aead`, `ecdsa`, `p256`, `p384`

### DIFF
--- a/.github/workflows/ring-compat.yml
+++ b/.github/workflows/ring-compat.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.41.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -57,7 +57,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.41.0 # MSRV
+          toolchain: 1.47.0 # MSRV
           components: clippy
           override: true
       - run: cargo clippy --all --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aead"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+checksum = "8aeaececfd937b9762778f2aca063ad24fdc827c48c07aeae36fb20c03afa11a"
 dependencies = [
  "generic-array",
 ]
@@ -43,6 +43,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "der"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83dc83d0b59f92103d8e661e60526338ad3aeb0c15fa4a29a14b6a9b1ac8a43c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,10 +63,11 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.8.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bf8bfb05ea8a6f74ddf48c7d1774851ba77bbe51ac984fdfa6c30310e1ff5f"
+checksum = "6b568b5e72165dd8913ac2aad6a60cb9cb297287615544c523c37f9247b58fc8"
 dependencies = [
+ "der",
  "elliptic-curve",
  "signature",
 ]
@@ -73,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.6.6"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396db09c483e7fca5d4fdb9112685632b3e76c9a607a2649c1bf904404a01366"
+checksum = "ee681bf25de1aad7cd02ccc7525d7b4bfab7be2493dbe3ee18d93f86eb3dcf3e"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -94,22 +104,9 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961de220ec9a91af2e1e5bd80d02109155695e516771762381ef8581317066e0"
-dependencies = [
- "hex-literal-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "hex-literal-impl"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853f769599eb31de176303197b7ba4973299c38c7a7604a6bc88c3eef05b9b46"
-dependencies = [
- "proc-macro-hack",
-]
+checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
 name = "js-sys"
@@ -155,9 +152,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.5.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280ed58e7e5f3052b6e2f596fa40c7eff4c27c4b6b6deecb5d685ba5c2080980"
+checksum = "1cf301f7f053902eaf046d541cd7b454a588b2bdd571f18195b57ae197aed2cb"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -165,19 +162,13 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.4.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06de0548166c258c22bb6bdcff3074eac4b07125040aa74db3f61db87fe5f275"
+checksum = "94e3bfd7d8f202c293072de214ad93480b533985bfee4fa4a13cfdd185fab13d"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro2"
@@ -199,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 
 [[package]]
 name = "ring"
@@ -237,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 dependencies = [
  "rand_core",
 ]
@@ -252,9 +243,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "subtle"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,19 +15,19 @@ categories = ["cryptography", "no-std"]
 keywords = ["aead", "digest", "crypto", "ring", "signature"]
 
 [dependencies]
-aead = { version = "0.3", optional = true, default-features = false }
+aead = { version = "0.4", optional = true, default-features = false }
 digest = { version = "0.9", optional = true }
-ecdsa = { version = "0.8", optional = true, default-features = false }
+ecdsa = { version = "0.11", optional = true, default-features = false }
 ed25519 = { version = "1", optional = true, default-features = false }
 generic-array = { version = "0.14", default-features = false }
 opaque-debug = "0.3"
-p256 = { version = "0.5", optional = true, default-features = false, features = ["ecdsa-core"] }
-p384 = { version = "0.4", optional = true, default-features = false, features = ["ecdsa"] }
+p256 = { version = "0.8", optional = true, default-features = false, features = ["ecdsa-core"] }
+p384 = { version = "0.7", optional = true, default-features = false, features = ["ecdsa"] }
 ring = { version = "0.16", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
-hex-literal = "0.2"
+hex-literal = "0.3"
 digest = { version = "0.9", features = ["dev"] }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ algorithm implementations from [*ring*].
 
 ## Minimum Supported Rust Version
 
-**Rust 1.41** or higher.
+**Rust 1.47** or higher.
 
 In the future the minimum supported Rust version can be changed, but it will be
 done with a minor version bump.
@@ -44,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/ring-compat/
 [docs-link]: https://docs.rs/ring-compat
 [ring-image]: https://img.shields.io/badge/ring-0.16-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260488-ring-compat

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -1,6 +1,6 @@
-//! Authenticated Encryption with Associated Data algorithms
+//! Authenticated Encryption with Associated Data Algorithms: AES-GCM, ChaCha20Poly1305
 
-pub use aead::{AeadInPlace, Buffer, Error, NewAead};
+pub use aead::{AeadCore, AeadInPlace, Buffer, Error, NewAead};
 
 #[cfg(feature = "alloc")]
 pub use aead::{Aead, Payload};
@@ -36,11 +36,13 @@ macro_rules! impl_aead {
             }
         }
 
-        impl AeadInPlace for $cipher {
+        impl AeadCore for $cipher {
             type NonceSize = U12;
             type TagSize = U16;
             type CiphertextOverhead = U0;
+        }
 
+        impl AeadInPlace for $cipher {
             fn encrypt_in_place_detached(
                 &self,
                 nonce: &GenericArray<u8, Self::NonceSize>,

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,4 +1,4 @@
-//! Digest algorighthms (a.k.a. hash functions)
+//! Digest algorithms: SHA-1, SHA-256, SHA-384, SHA-512
 
 use core::mem;
 use digest::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,6 @@
 //! Compatibility crate for using [RustCrypto traits] with the cryptographic
 //! algorithm implementations from [*ring*].
 //!
-//! Supported algorithms:
-//!
-//! - [`aead`]: AES-GCM, ChaCha20Poly1305
-//! - [`digest`]: SHA-2 family
-//! - [`signature`]: ECDSA, Ed25519
-//!
 //! [RustCrypto traits]: https://github.com/RustCrypto/traits
 //! [*ring*]: https://github.com/briansmith/ring
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,4 +1,4 @@
-//! Digital signature support
+//! Digital signatures: ECDSA, Ed25519
 
 pub mod ecdsa;
 pub mod ed25519;

--- a/src/signature/ecdsa.rs
+++ b/src/signature/ecdsa.rs
@@ -9,7 +9,7 @@ mod signing_key;
 mod verify_key;
 
 pub use self::{signing_key::SigningKey, verify_key::VerifyKey};
-pub use ::ecdsa::{asn1, elliptic_curve::weierstrass::Curve, Signature};
+pub use ::ecdsa::{der, elliptic_curve::weierstrass::Curve, Signature};
 
 use ring::signature::{EcdsaSigningAlgorithm, EcdsaVerificationAlgorithm};
 

--- a/src/signature/ecdsa/signing_key.rs
+++ b/src/signature/ecdsa/signing_key.rs
@@ -3,12 +3,15 @@
 use super::{Curve, CurveAlg, Signature, VerifyKey};
 use crate::signature::{Error, Signature as _, Signer};
 use ::ecdsa::{
-    elliptic_curve::sec1::{UncompressedPointSize, UntaggedPointSize},
-    generic_array::{typenum::U1, ArrayLength},
-    CheckSignatureBytes, SignatureSize,
+    elliptic_curve::{
+        sec1::{UncompressedPointSize, UntaggedPointSize},
+        Order,
+    },
+    SignatureSize,
 };
 use core::marker::PhantomData;
 use core::ops::Add;
+use generic_array::{typenum::U1, ArrayLength};
 use ring::{
     self,
     rand::SystemRandom,
@@ -18,7 +21,7 @@ use ring::{
 /// ECDSA signing key. Generic over elliptic curves.
 pub struct SigningKey<C>
 where
-    C: Curve + CurveAlg + CheckSignatureBytes,
+    C: Curve + CurveAlg + Order,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// *ring* ECDSA keypair
@@ -33,7 +36,7 @@ where
 
 impl<C> SigningKey<C>
 where
-    C: Curve + CurveAlg + CheckSignatureBytes,
+    C: Curve + CurveAlg + Order,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Initialize a [`SigningKey`] from a PKCS#8-encoded private key
@@ -70,7 +73,7 @@ where
 
 impl<C> Signer<Signature<C>> for SigningKey<C>
 where
-    C: Curve + CurveAlg + CheckSignatureBytes,
+    C: Curve + CurveAlg + Order,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<Signature<C>, Error> {

--- a/src/signature/ecdsa/verify_key.rs
+++ b/src/signature/ecdsa/verify_key.rs
@@ -3,28 +3,31 @@
 use super::{Curve, CurveAlg, Signature};
 use crate::signature::{Error, Verifier};
 use ::ecdsa::{
-    elliptic_curve::sec1::{self, UncompressedPointSize, UntaggedPointSize},
-    generic_array::{
-        typenum::{Unsigned, U1},
-        ArrayLength,
+    elliptic_curve::{
+        sec1::{self, UncompressedPointSize, UntaggedPointSize},
+        Order,
     },
-    CheckSignatureBytes, SignatureSize,
+    SignatureSize,
 };
 use core::{convert::TryInto, ops::Add};
+use generic_array::{
+    typenum::{Unsigned, U1},
+    ArrayLength,
+};
 use ring::signature::UnparsedPublicKey;
 
 /// ECDSA verify key. Generic over elliptic curves.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerifyKey<C>(sec1::EncodedPoint<C>)
 where
-    C: Curve + CurveAlg + CheckSignatureBytes,
+    C: Curve + CurveAlg + Order,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>;
 
 impl<C> VerifyKey<C>
 where
-    C: Curve + CurveAlg + CheckSignatureBytes,
+    C: Curve + CurveAlg + Order,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
@@ -50,7 +53,7 @@ where
 
 impl<C: Curve> Verifier<Signature<C>> for VerifyKey<C>
 where
-    C: Curve + CurveAlg + CheckSignatureBytes,
+    C: Curve + CurveAlg + Order,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,


### PR DESCRIPTION
Bumps the following crate dependencies:

- `aead` v0.4
- `ecdsa` v0.11
- `p256` v0.8
- `p384` v0.7