### PR TITLE
v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2021-04-30)
+### Added
+- `std` feature that enables `digest/std` ([#33])
+
+### Changed
+- Bump `aead` to v0.4 ([#34])
+- Bump `ecdsa` to v0.11 ([#34])
+- Bump `p256` to v0.8 ([#34])
+- Bump `p384` to v0.7 ([#34])
+
+[#33]: https://github.com/RustCrypto/ring-compat/pull/33
+[#34]: https://github.com/RustCrypto/ring-compat/pull/34
+
 ## 0.1.1 (2020-12-11)
 ### Added
 - `ecdsa::VerifyKey::as_bytes()` function ([#21])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "ring-compat"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "aead",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-compat"
-version = "0.1.1"
+version = "0.2.0"
 description = """
 Compatibility crate for using RustCrypto's traits with the cryptographic
 algorithm implementations from *ring*


### PR DESCRIPTION
### Added
- `std` feature that enables `digest/std` ([#33])

### Changed
- Bump `aead` to v0.4 ([#34])
- Bump `ecdsa` to v0.11 ([#34])
- Bump `p256` to v0.8 ([#34])
- Bump `p384` to v0.7 ([#34])

[#33]: https://github.com/RustCrypto/ring-compat/pull/33
[#34]: https://github.com/RustCrypto/ring-compat/pull/34