### PR TITLE
Rename `VerifyKey` => `VerifyingKey`

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,4 +1,4 @@
-//! Digital signatures: ECDSA, Ed25519
+//! Digital signatures: ECDSA (P-256/P-384), Ed25519
 
 pub mod ecdsa;
 pub mod ed25519;

--- a/src/signature/ecdsa.rs
+++ b/src/signature/ecdsa.rs
@@ -6,9 +6,9 @@ pub mod p256;
 pub mod p384;
 
 mod signing_key;
-mod verify_key;
+mod verifying_key;
 
-pub use self::{signing_key::SigningKey, verify_key::VerifyKey};
+pub use self::{signing_key::SigningKey, verifying_key::VerifyingKey};
 pub use ::ecdsa::{der, elliptic_curve::weierstrass::Curve, Signature};
 
 use ring::signature::{EcdsaSigningAlgorithm, EcdsaVerificationAlgorithm};

--- a/src/signature/ecdsa/p256.rs
+++ b/src/signature/ecdsa/p256.rs
@@ -15,7 +15,7 @@ pub type Signature = super::Signature<NistP256>;
 pub type SigningKey = super::SigningKey<NistP256>;
 
 /// ECDSA/P-256 verify key
-pub type VerifyKey = super::VerifyKey<NistP256>;
+pub type VerifyingKey = super::VerifyingKey<NistP256>;
 
 impl CurveAlg for NistP256 {
     fn signing_alg() -> &'static EcdsaSigningAlgorithm {

--- a/src/signature/ecdsa/p384.rs
+++ b/src/signature/ecdsa/p384.rs
@@ -15,7 +15,7 @@ pub type Signature = super::Signature<NistP384>;
 pub type SigningKey = super::SigningKey<NistP384>;
 
 /// ECDSA/P-384 verify key
-pub type VerifyKey = super::VerifyKey<NistP384>;
+pub type VerifyingKey = super::VerifyingKey<NistP384>;
 
 impl CurveAlg for NistP384 {
     fn signing_alg() -> &'static EcdsaSigningAlgorithm {

--- a/src/signature/ecdsa/signing_key.rs
+++ b/src/signature/ecdsa/signing_key.rs
@@ -1,6 +1,6 @@
 //! ECDSA signing key
 
-use super::{Curve, CurveAlg, Signature, VerifyKey};
+use super::{Curve, CurveAlg, Signature, VerifyingKey};
 use crate::signature::{Error, Signature as _, Signer};
 use ::ecdsa::{
     elliptic_curve::{
@@ -61,13 +61,13 @@ where
             .map_err(|_| Error::new())
     }
 
-    /// Get the [`VerifyKey`] for this [`SigningKey`]
-    pub fn verify_key(&self) -> VerifyKey<C>
+    /// Get the [`VerifyingKey`] for this [`SigningKey`]
+    pub fn verify_key(&self) -> VerifyingKey<C>
     where
         UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
         UncompressedPointSize<C>: ArrayLength<u8>,
     {
-        VerifyKey::new(self.keypair.public_key().as_ref()).unwrap()
+        VerifyingKey::new(self.keypair.public_key().as_ref()).unwrap()
     }
 }
 

--- a/src/signature/ecdsa/verifying_key.rs
+++ b/src/signature/ecdsa/verifying_key.rs
@@ -1,4 +1,4 @@
-//! ECDSA verify key
+//! ECDSA verifying key
 
 use super::{Curve, CurveAlg, Signature};
 use crate::signature::{Error, Verifier};
@@ -16,23 +16,23 @@ use generic_array::{
 };
 use ring::signature::UnparsedPublicKey;
 
-/// ECDSA verify key. Generic over elliptic curves.
+/// ECDSA verifying key. Generic over elliptic curves.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct VerifyKey<C>(sec1::EncodedPoint<C>)
+pub struct VerifyingKey<C>(sec1::EncodedPoint<C>)
 where
     C: Curve + CurveAlg + Order,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>;
 
-impl<C> VerifyKey<C>
+impl<C> VerifyingKey<C>
 where
     C: Curve + CurveAlg + Order,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
-    /// Initialize [`VerifyKey`] from a SEC1-encoded public key
+    /// Initialize [`VerifyingKey`] from a SEC1-encoded public key
     pub fn new(bytes: &[u8]) -> Result<Self, Error> {
         let point_result = if bytes.len() == C::FieldSize::to_usize() * 2 {
             Ok(sec1::EncodedPoint::from_untagged_bytes(
@@ -42,7 +42,7 @@ where
             sec1::EncodedPoint::from_bytes(bytes)
         };
 
-        point_result.map(VerifyKey).map_err(|_| Error::new())
+        point_result.map(VerifyingKey).map_err(|_| Error::new())
     }
 
     /// Get byte slice of inner encoded point
@@ -51,7 +51,7 @@ where
     }
 }
 
-impl<C: Curve> Verifier<Signature<C>> for VerifyKey<C>
+impl<C: Curve> Verifier<Signature<C>> for VerifyingKey<C>
 where
     C: Curve + CurveAlg + Order,
     SignatureSize<C>: ArrayLength<u8>,

--- a/src/signature/ed25519.rs
+++ b/src/signature/ed25519.rs
@@ -11,33 +11,30 @@ use ring::{
     signature::{Ed25519KeyPair, KeyPair, UnparsedPublicKey},
 };
 
-/// Size of a raw [`SigningKey`] (a.k.a. seed) in bytes
-pub const SIGNING_KEY_LENGTH: usize = 32;
-
-/// Size of a [`VerifyKey`] in bytes
-pub const VERIFY_KEY_LENGTH: usize = 32;
-
-/// Ed25519 signing key
+/// Ed25519 signing key.
 pub struct SigningKey(Ed25519KeyPair);
 
 impl SigningKey {
-    /// Create a new [`SigningKey`] from an unexpanded seed value (32-bytes)
+    /// Size of a raw [`SigningKey`] (a.k.a. seed) in bytes.
+    pub const SIZE: usize = 32;
+
+    /// Create a new [`SigningKey`] from an unexpanded seed value (32-bytes).
     pub fn from_seed(seed: &[u8]) -> Result<Self, Error> {
         Ed25519KeyPair::from_seed_unchecked(seed)
             .map(SigningKey)
             .map_err(|_| Error::new())
     }
 
-    /// Create a new [`SigningKey`] from a PKCS#8 encoded  key
+    /// Create a new [`SigningKey`] from a PKCS#8 encoded key.
     pub fn from_pkcs8(pkcs8_key: &[u8]) -> Result<Self, Error> {
         Ed25519KeyPair::from_pkcs8(pkcs8_key)
             .map(SigningKey)
             .map_err(|_| Error::new())
     }
 
-    /// Get the [`VerifyKey`] for this [`SigningKey`]
-    pub fn verify_key(&self) -> VerifyKey {
-        VerifyKey(self.0.public_key().as_ref().try_into().unwrap())
+    /// Get the [`VerifyingKey`] for this [`SigningKey`].
+    pub fn verify_key(&self) -> VerifyingKey {
+        VerifyingKey(self.0.public_key().as_ref().try_into().unwrap())
     }
 }
 
@@ -47,30 +44,33 @@ impl Signer<Signature> for SigningKey {
     }
 }
 
-/// Ed25519 verify key
+/// Ed25519 verifying key.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct VerifyKey([u8; VERIFY_KEY_LENGTH]);
+pub struct VerifyingKey([u8; Self::SIZE]);
 
-impl VerifyKey {
-    /// Parse a verify key (encoded in compressed Edwards-y form) from bytes
+impl VerifyingKey {
+    /// Size of a [`VerifyingKey`] in bytes.
+    pub const SIZE: usize = 32;
+
+    /// Parse a verify key (encoded in compressed Edwards-y form) from bytes.
     pub fn new(bytes: &[u8]) -> Result<Self, Error> {
-        bytes.try_into().map(VerifyKey).map_err(|_| Error::new())
+        bytes.try_into().map(VerifyingKey).map_err(|_| Error::new())
     }
 }
 
-impl AsRef<[u8]> for VerifyKey {
+impl AsRef<[u8]> for VerifyingKey {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl From<&SigningKey> for VerifyKey {
+impl From<&SigningKey> for VerifyingKey {
     fn from(signing_key: &SigningKey) -> Self {
         signing_key.verify_key()
     }
 }
 
-impl Verifier<Signature> for VerifyKey {
+impl Verifier<Signature> for VerifyingKey {
     fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), Error> {
         UnparsedPublicKey::new(&ring::signature::ED25519, self.0.as_ref())
             .verify(msg, signature.as_ref())

--- a/tests/signature/ecdsa/p256.rs
+++ b/tests/signature/ecdsa/p256.rs
@@ -3,11 +3,11 @@
 use crate::{ecdsa_tests, signature::TestVector};
 use core::convert::TryFrom;
 use ring_compat::signature::{
-    ecdsa::p256::{Signature, SigningKey, VerifyKey},
+    ecdsa::p256::{Signature, SigningKey, VerifyingKey},
     Signer, Verifier,
 };
 
-ecdsa_tests!(SigningKey, VerifyKey, TEST_VECTORS);
+ecdsa_tests!(SigningKey, VerifyingKey, TEST_VECTORS);
 
 /// ECDSA test vectors for the NIST P-256 elliptic curve (SHA-256)
 ///

--- a/tests/signature/ecdsa/p384.rs
+++ b/tests/signature/ecdsa/p384.rs
@@ -3,11 +3,11 @@
 use crate::{ecdsa_tests, signature::TestVector};
 use core::convert::TryFrom;
 use ring_compat::signature::{
-    ecdsa::p384::{Signature, SigningKey, VerifyKey},
+    ecdsa::p384::{Signature, SigningKey, VerifyingKey},
     Signer, Verifier,
 };
 
-ecdsa_tests!(SigningKey, VerifyKey, TEST_VECTORS);
+ecdsa_tests!(SigningKey, VerifyingKey, TEST_VECTORS);
 
 /// ECDSA test vectors for the NIST P-384 elliptic curve
 ///

--- a/tests/signature/ed25519.rs
+++ b/tests/signature/ed25519.rs
@@ -2,7 +2,7 @@
 
 use super::TestVector;
 use ring_compat::signature::{
-    ed25519::{Signature, SigningKey, VerifyKey, SIGNATURE_LENGTH},
+    ed25519::{Signature, SigningKey, VerifyingKey, SIGNATURE_LENGTH},
     Signature as _, Signer, Verifier,
 };
 
@@ -17,7 +17,7 @@ fn sign_rfc8032_test_vectors() {
 #[test]
 fn verify_rfc8032_test_vectors() {
     for vector in TEST_VECTORS {
-        let verify_key = VerifyKey::new(vector.pk).unwrap();
+        let verify_key = VerifyingKey::new(vector.pk).unwrap();
         let sig = Signature::from_bytes(vector.sig).unwrap();
         assert!(verify_key.verify(vector.msg, &sig).is_ok());
     }
@@ -26,7 +26,7 @@ fn verify_rfc8032_test_vectors() {
 #[test]
 fn rejects_tweaked_rfc8032_test_vectors() {
     for vector in TEST_VECTORS {
-        let verify_key = VerifyKey::new(vector.pk).unwrap();
+        let verify_key = VerifyingKey::new(vector.pk).unwrap();
 
         let mut tweaked_sig = [0u8; SIGNATURE_LENGTH];
         tweaked_sig.copy_from_slice(vector.sig);


### PR DESCRIPTION
Note: this is a breaking change. The plan is to yank the v0.2.0 release from a few hours ago.

Aligns with the `VerifyingKey` name from the `ecdsa` crate, which in turn better aligns with the `SigningKey` name.