### PR TITLE
v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2021-04-30)
+## 0.2.1 (2021-04-30)
+### Changed
+- Rename `VerifyKey` => `VerifyingKey` ([#38])
+
+[#38]: https://github.com/RustCrypto/ring-compat/pull/38
+
+## 0.2.0 (2021-04-30) [YANKED]
 ### Added
 - `std` feature that enables `digest/std` ([#33])
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "ring-compat"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aead",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-compat"
-version = "0.2.0"
+version = "0.2.1"
 description = """
 Compatibility crate for using RustCrypto's traits with the cryptographic
 algorithm implementations from *ring*


### PR DESCRIPTION
### Changed
- Rename `VerifyKey` => `VerifyingKey` ([#38])

[#38]: https://github.com/RustCrypto/ring-compat/pull/38
