### PR TITLE
Bump `ecdsa`, `p256`, `p384`; MSRV 1.51+

### DIFF
--- a/.github/workflows/ring-compat.yml
+++ b/.github/workflows/ring-compat.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.47.0 # MSRV
+          - 1.51.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -57,7 +57,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.47.0 # MSRV
+          toolchain: 1.51.0 # MSRV
           components: clippy
           override: true
       - run: cargo clippy --all --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,13 +45,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "der"
-version = "0.3.5"
+name = "crypto-bigint"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eeb9d92785d1facb50567852ce75d0858630630e7eabea59cf7eb7474051087"
+checksum = "281d926f72b42bf3ba840b88cd53e39f36be9f66e34c8df3fb336372b3753d41"
 dependencies = [
- "typenum",
+ "generic-array",
+ "subtle",
 ]
+
+[[package]]
+name = "der"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f215f706081a44cb702c71c39a52c05da637822e9c1645a50b7202689e982d"
 
 [[package]]
 name = "digest"
@@ -65,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d33b390ab82f2e1481e331dbd0530895640179d2128ef9a79cc690b78d1eba"
+checksum = "1a6cc9051fd9ca5710db0141855d83e666d12f3987359986d52ba4d200343052"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -85,10 +92,11 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.9.12"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13e9b0c3c4170dcc2a12783746c4205d98e18957f57854251eea3f9750fe005"
+checksum = "ade912ac38a947c8bff6d07bcf0ef97327027837963b0452e6f2a9e78b734ebf"
 dependencies = [
+ "crypto-bigint",
  "generic-array",
  "rand_core",
  "subtle",
@@ -154,9 +162,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f05f5287453297c4c16af5e2b04df8fd2a3008d70f252729650bc6d7ace5844"
+checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -164,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e3bfd7d8f202c293072de214ad93480b533985bfee4fa4a13cfdd185fab13d"
+checksum = "f23bc88c404ccc881c8a1ad62ba5cd7d336a64ecbf46de4874f2ad955f67b157"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ keywords = ["aead", "digest", "crypto", "ring", "signature"]
 [dependencies]
 aead = { version = "0.4", optional = true, default-features = false }
 digest = { version = "0.9", optional = true }
-ecdsa = { version = "0.11", optional = true, default-features = false }
+ecdsa = { version = "0.12", optional = true, default-features = false }
 ed25519 = { version = "1", optional = true, default-features = false }
 generic-array = { version = "0.14", default-features = false }
 opaque-debug = "0.3"
-p256 = { version = "0.8", optional = true, default-features = false, features = ["ecdsa-core"] }
-p384 = { version = "0.7", optional = true, default-features = false, features = ["ecdsa"] }
+p256 = { version = "0.9", optional = true, default-features = false, features = ["ecdsa-core"] }
+p384 = { version = "0.8", optional = true, default-features = false, features = ["ecdsa"] }
 ring = { version = "0.16", default-features = false }
 zeroize = { version = "1", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ algorithm implementations from [*ring*].
 
 ## Minimum Supported Rust Version
 
-**Rust 1.47** or higher.
+**Rust 1.51** or higher.
 
 In the future the minimum supported Rust version can be changed, but it will be
 done with a minor version bump.
@@ -44,7 +44,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-link]: https://docs.rs/ring-compat/
 [docs-link]: https://docs.rs/ring-compat
 [ring-image]: https://img.shields.io/badge/ring-0.16-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.51+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260488-ring-compat

--- a/src/signature/ecdsa/signing_key.rs
+++ b/src/signature/ecdsa/signing_key.rs
@@ -3,10 +3,7 @@
 use super::{Curve, CurveAlg, Signature, VerifyingKey};
 use crate::signature::{Error, Signature as _, Signer};
 use ::ecdsa::{
-    elliptic_curve::{
-        sec1::{UncompressedPointSize, UntaggedPointSize},
-        Order,
-    },
+    elliptic_curve::sec1::{UncompressedPointSize, UntaggedPointSize},
     SignatureSize,
 };
 use core::marker::PhantomData;
@@ -21,7 +18,7 @@ use ring::{
 /// ECDSA signing key. Generic over elliptic curves.
 pub struct SigningKey<C>
 where
-    C: Curve + CurveAlg + Order,
+    C: Curve + CurveAlg,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// *ring* ECDSA keypair
@@ -36,7 +33,7 @@ where
 
 impl<C> SigningKey<C>
 where
-    C: Curve + CurveAlg + Order,
+    C: Curve + CurveAlg,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Initialize a [`SigningKey`] from a PKCS#8-encoded private key
@@ -73,7 +70,7 @@ where
 
 impl<C> Signer<Signature<C>> for SigningKey<C>
 where
-    C: Curve + CurveAlg + Order,
+    C: Curve + CurveAlg,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<Signature<C>, Error> {

--- a/src/signature/ecdsa/verifying_key.rs
+++ b/src/signature/ecdsa/verifying_key.rs
@@ -4,37 +4,34 @@ use super::{Curve, CurveAlg, Signature};
 use crate::signature::{Error, Verifier};
 use ::ecdsa::{
     elliptic_curve::{
+        bigint::Encoding as _,
         sec1::{self, UncompressedPointSize, UntaggedPointSize},
-        Order,
     },
     SignatureSize,
 };
 use core::{convert::TryInto, ops::Add};
-use generic_array::{
-    typenum::{Unsigned, U1},
-    ArrayLength,
-};
+use generic_array::{typenum::U1, ArrayLength};
 use ring::signature::UnparsedPublicKey;
 
 /// ECDSA verifying key. Generic over elliptic curves.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerifyingKey<C>(sec1::EncodedPoint<C>)
 where
-    C: Curve + CurveAlg + Order,
+    C: Curve + CurveAlg,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>;
 
 impl<C> VerifyingKey<C>
 where
-    C: Curve + CurveAlg + Order,
+    C: Curve + CurveAlg,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,
 {
     /// Initialize [`VerifyingKey`] from a SEC1-encoded public key
     pub fn new(bytes: &[u8]) -> Result<Self, Error> {
-        let point_result = if bytes.len() == C::FieldSize::to_usize() * 2 {
+        let point_result = if bytes.len() == C::UInt::BYTE_SIZE * 2 {
             Ok(sec1::EncodedPoint::from_untagged_bytes(
                 bytes.try_into().unwrap(),
             ))
@@ -53,7 +50,7 @@ where
 
 impl<C: Curve> Verifier<Signature<C>> for VerifyingKey<C>
 where
-    C: Curve + CurveAlg + Order,
+    C: Curve + CurveAlg,
     SignatureSize<C>: ArrayLength<u8>,
     UntaggedPointSize<C>: Add<U1> + ArrayLength<u8>,
     UncompressedPointSize<C>: ArrayLength<u8>,


### PR DESCRIPTION
Bumps the following crate dependencies:

- `ecdsa` v0.12
- `p256` v0.9
- `p384` v0.8