### PR TITLE
v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2021-12-15)
+### Changed
+- Bump `ecdsa` to v0.13 ([#65])
+- Bump `p256` to v0.10 ([#65])
+- Bump `p384` to v0.9 ([#65])
+- Rust 2021 edition upgrade ([#66])
+
+[#65]: https://github.com/RustCrypto/ring-compat/pull/65
+[#66]: https://github.com/RustCrypto/ring-compat/pull/66
+
 ## 0.3.2 (2021-09-14)
 - Republishing with identical code to v0.3.1 to update the crates.io description.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "ring-compat"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aead",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-compat"
-version = "0.4.0-pre"
+version = "0.4.0"
 description = """
 Compatibility crate for using RustCrypto's traits with the cryptographic
 algorithm implementations from *ring*


### PR DESCRIPTION
### Changed
- Bump `ecdsa` to v0.13 ([#65])
- Bump `p256` to v0.10 ([#65])
- Bump `p384` to v0.9 ([#65])
- Rust 2021 edition upgrade ([#66])

[#65]: https://github.com/RustCrypto/ring-compat/pull/65
[#66]: https://github.com/RustCrypto/ring-compat/pull/66