### PR TITLE
reexport the ring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,3 +36,4 @@ pub mod digest;
 pub mod signature;
 
 pub use generic_array;
+pub use ring;


### PR DESCRIPTION
Reexporting the `ring` that the library was using. That would be convenient for users to use the same version of `ring`.