### PR TITLE
v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1 (2022-03-12)
+### Added
+- Re-export `ring` ([#80])
+
+### Changed
+- Reuse AEAD cipher instance ([#79])
+
+[#79]: https://github.com/RustCrypto/ring-compat/pull/79
+[#80]: https://github.com/RustCrypto/ring-compat/pull/80
+
 ## 0.4.0 (2021-12-15)
 ### Changed
 - Bump `ecdsa` to v0.13 ([#65])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "ring-compat"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aead",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-compat"
-version = "0.4.0"
+version = "0.4.1"
 description = """
 Compatibility crate for using RustCrypto's traits with the cryptographic
 algorithm implementations from *ring*


### PR DESCRIPTION
### Added
- Re-export `ring` ([#80])

### Changed
- Reuse AEAD cipher instance ([#79])

[#79]: https://github.com/RustCrypto/ring-compat/pull/79
[#80]: https://github.com/RustCrypto/ring-compat/pull/80