### PR TITLE
Fix unnecessary use of `mem::drop`

### DIFF
--- a/.github/workflows/ring-compat.yml
+++ b/.github/workflows/ring-compat.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0 # MSRV
+          toolchain: 1.65.0 # MSRV
           components: clippy
           override: true
       - run: cargo clippy --all --all-features -- -D warnings

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -58,7 +58,7 @@ macro_rules! impl_digest {
 
         impl Reset for $name {
             fn reset(&mut self) {
-                mem::drop(self.take());
+                self.take();
             }
         }
 


### PR DESCRIPTION
This makes clippy clean on Rust 1.65