### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2022-12-11)
+### Added
+- Impl `pkcs8::DecodePrivateKey` for ECDSA and Ed25519 signing keys ([#99])
+
+### Changed
+- Bump `aead` dependency to v0.5 ([#86])
+- Bump `digest` to v0.10 ([#94])
+- Bump `p256` and `p384` to v0.11 ([#95])
+- Use namespaced/weak features; MSRV 1.60 ([#97])
+- Rename `verify_key` => `verifying_key` ([#98])
+
+[#86]: https://github.com/RustCrypto/ring-compat/pull/86
+[#94]: https://github.com/RustCrypto/ring-compat/pull/94
+[#95]: https://github.com/RustCrypto/ring-compat/pull/95
+[#97]: https://github.com/RustCrypto/ring-compat/pull/97
+[#98]: https://github.com/RustCrypto/ring-compat/pull/98
+[#99]: https://github.com/RustCrypto/ring-compat/pull/99
+
 ## 0.4.1 (2022-03-12)
 ### Added
 - Re-export `ring` ([#80])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "ring-compat"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "aead",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-compat"
-version = "0.4.1"
+version = "0.5.0"
 description = """
 Compatibility crate for using RustCrypto's traits with the cryptographic
 algorithm implementations from *ring*


### PR DESCRIPTION
### Added
- Impl `pkcs8::DecodePrivateKey` for ECDSA and Ed25519 signing keys ([#99])

### Changed
- Bump `aead` dependency to v0.5 ([#86])
- Bump `digest` to v0.10 ([#94])
- Bump `p256` and `p384` to v0.11 ([#95])
- Use namespaced/weak features; MSRV 1.60 ([#97])
- Rename `verify_key` => `verifying_key` ([#98])

[#86]: https://github.com/RustCrypto/ring-compat/pull/86
[#94]: https://github.com/RustCrypto/ring-compat/pull/94
[#95]: https://github.com/RustCrypto/ring-compat/pull/95
[#97]: https://github.com/RustCrypto/ring-compat/pull/97
[#98]: https://github.com/RustCrypto/ring-compat/pull/98
[#99]: https://github.com/RustCrypto/ring-compat/pull/99