### PR TITLE
Map some error instead of unwrap

### DIFF
--- a/src/aead.rs
+++ b/src/aead.rs
@@ -100,7 +100,7 @@ impl Cipher {
     ) -> Result<Tag, Error> {
         self.0
             .seal_in_place_separate_tag(
-                Nonce::try_assume_unique_for_key(nonce).unwrap(),
+                Nonce::try_assume_unique_for_key(nonce).map_err(|_| Error)?,
                 Aad::from(associated_data),
                 buffer,
             )
@@ -117,7 +117,7 @@ impl Cipher {
         let pt_len = self
             .0
             .open_in_place(
-                Nonce::try_assume_unique_for_key(nonce).unwrap(),
+                Nonce::try_assume_unique_for_key(nonce).map_err(|_| Error)?,
                 Aad::from(associated_data),
                 buffer.as_mut(),
             )

--- a/src/signature/ecdsa/verifying_key.rs
+++ b/src/signature/ecdsa/verifying_key.rs
@@ -28,7 +28,7 @@ where
     pub fn new(bytes: &[u8]) -> Result<Self, Error> {
         let point_result = if bytes.len() == C::UInt::BYTE_SIZE * 2 {
             Ok(sec1::EncodedPoint::<C>::from_untagged_bytes(
-                bytes.try_into().unwrap(),
+                bytes.try_into().map_err(|_| Error::new())?,
             ))
         } else {
             sec1::EncodedPoint::<C>::from_bytes(bytes)

--- a/src/signature/ed25519.rs
+++ b/src/signature/ed25519.rs
@@ -50,7 +50,7 @@ impl TryFrom<PrivateKeyInfo<'_>> for SigningKey {
 
 impl Signer<Signature> for SigningKey {
     fn try_sign(&self, msg: &[u8]) -> Result<Signature, Error> {
-        Ok(Signature::from_bytes(self.0.sign(msg).as_ref()).unwrap())
+        Ok(Signature::from_bytes(self.0.sign(msg).as_ref())?)
     }
 }
 

--- a/src/signature/ed25519.rs
+++ b/src/signature/ed25519.rs
@@ -50,7 +50,7 @@ impl TryFrom<PrivateKeyInfo<'_>> for SigningKey {
 
 impl Signer<Signature> for SigningKey {
     fn try_sign(&self, msg: &[u8]) -> Result<Signature, Error> {
-        Ok(Signature::from_bytes(self.0.sign(msg).as_ref())?)
+        Signature::from_bytes(self.0.sign(msg).as_ref())
     }
 }
 


### PR DESCRIPTION
Currently a few function that return result still unwrap, most of those are safe but we can do better, this PR map where possible