### PR TITLE
Upgrade to `signature` v2-compatible dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "82508ce57bd2b245e9914411800f87fd8fc8288f501bb26919cb9b2ee964028f"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.4.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
+checksum = "b313941b79fa8f26c1967e351fa7f48a144e2dbeadb6a6fe0ccdfd61ef8ad600"
 dependencies = [
  "signature",
 ]
@@ -136,11 +136,23 @@ dependencies = [
  "crypto-bigint",
  "der",
  "digest",
+ "ff",
  "generic-array",
+ "group",
  "rand_core",
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -162,6 +174,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -214,22 +237,24 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
 ]
 
 [[package]]
 name = "p384"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
+checksum = "630a4a9b2618348ececfae61a4905f564b817063bf2d66cdfc2ced523fe1d2d4"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
 ]
 
 [[package]]
@@ -240,6 +265,15 @@ checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b7e10b3a364b1c813238b1c9a749336cbe51fd4265cd99f57cf29302c90af7"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -262,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -286,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "ring-compat"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "aead",
  "digest",
@@ -318,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "rand_core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-compat"
-version = "0.5.1"
+version = "0.6.0-pre"
 description = """
 Compatibility crate for using RustCrypto's traits with the cryptographic
 algorithm implementations from *ring*
@@ -23,12 +23,12 @@ ring = { version = "0.16", default-features = false }
 # optional dependencies
 aead = { version = "0.5", optional = true, default-features = false }
 digest = { version = "0.10", optional = true }
-ecdsa = { version = "0.14", optional = true, default-features = false }
-ed25519 = { version = "1.4", optional = true, default-features = false }
-p256 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa-core"] }
-p384 = { version = "0.11", optional = true, default-features = false, features = ["ecdsa-core"] }
+ecdsa = { version = "0.15", optional = true, default-features = false }
+ed25519 = { version = "2", optional = true, default-features = false }
+p256 = { version = "0.12", optional = true, default-features = false, features = ["ecdsa-core"] }
+p384 = { version = "0.12", optional = true, default-features = false, features = ["ecdsa-core"] }
 pkcs8 = { version = "0.9", optional = true, default-features = false }
-signature = { version = "1", optional = true, default-features = false }
+signature = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -3,4 +3,4 @@
 pub mod ecdsa;
 pub mod ed25519;
 
-pub use ::signature::{Error, Signature, Signer, Verifier};
+pub use ::signature::{Error, SignatureEncoding, Signer, Verifier};

--- a/src/signature/ecdsa/signing_key.rs
+++ b/src/signature/ecdsa/signing_key.rs
@@ -1,7 +1,7 @@
 //! ECDSA signing key
 
 use super::{CurveAlg, PrimeCurve, Signature, VerifyingKey};
-use crate::signature::{Error, Signature as _, Signer};
+use crate::signature::{Error, Signer};
 use ::ecdsa::{
     elliptic_curve::{sec1, FieldSize},
     SignatureSize,
@@ -93,6 +93,6 @@ where
         self.keypair
             .sign(&self.csrng, msg)
             .map_err(|_| Error::new())
-            .and_then(|sig| Signature::from_bytes(sig.as_ref()))
+            .and_then(|sig| Signature::try_from(sig.as_ref()))
     }
 }

--- a/src/signature/ecdsa/verifying_key.rs
+++ b/src/signature/ecdsa/verifying_key.rs
@@ -51,7 +51,7 @@ where
 {
     fn verify(&self, msg: &[u8], sig: &Signature<C>) -> Result<(), Error> {
         UnparsedPublicKey::new(C::verify_alg(), self.0.as_ref())
-            .verify(msg, sig.as_ref())
+            .verify(msg, &sig.to_bytes())
             .map_err(|_| Error::new())
     }
 }

--- a/src/signature/ed25519.rs
+++ b/src/signature/ed25519.rs
@@ -50,7 +50,7 @@ impl TryFrom<PrivateKeyInfo<'_>> for SigningKey {
 
 impl Signer<Signature> for SigningKey {
     fn try_sign(&self, msg: &[u8]) -> Result<Signature, Error> {
-        Signature::from_bytes(self.0.sign(msg).as_ref())
+        Ok(Signature::try_from(self.0.sign(msg).as_ref()).unwrap())
     }
 }
 
@@ -83,7 +83,7 @@ impl From<&SigningKey> for VerifyingKey {
 impl Verifier<Signature> for VerifyingKey {
     fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), Error> {
         UnparsedPublicKey::new(&ring::signature::ED25519, self.0.as_ref())
-            .verify(msg, signature.as_ref())
+            .verify(msg, &signature.to_bytes())
             .map_err(|_| Error::new())
     }
 }

--- a/tests/signature/ed25519.rs
+++ b/tests/signature/ed25519.rs
@@ -11,7 +11,7 @@ use ring_compat::signature::{
 fn sign_rfc8032_test_vectors() {
     for vector in TEST_VECTORS {
         let signing_key = SigningKey::from_seed(vector.sk).unwrap();
-        assert_eq!(signing_key.sign(vector.msg).as_ref(), vector.sig);
+        assert_eq!(signing_key.sign(vector.msg).to_bytes(), vector.sig);
     }
 }
 
@@ -19,7 +19,7 @@ fn sign_rfc8032_test_vectors() {
 fn verify_rfc8032_test_vectors() {
     for vector in TEST_VECTORS {
         let verifying_key = VerifyingKey::new(vector.pk).unwrap();
-        let sig = Signature::from_bytes(vector.sig).unwrap();
+        let sig = Signature::try_from(vector.sig).unwrap();
         assert!(verifying_key.verify(vector.msg, &sig).is_ok());
     }
 }
@@ -33,7 +33,7 @@ fn rejects_tweaked_rfc8032_test_vectors() {
         tweaked_sig.copy_from_slice(vector.sig);
         tweaked_sig[0] ^= 0x42;
 
-        let sig = Signature::from_bytes(&tweaked_sig[..]).unwrap();
+        let sig = Signature::try_from(&tweaked_sig[..]).unwrap();
         assert!(verifying_key.verify(vector.msg, &sig).is_err());
     }
 }


### PR DESCRIPTION
Bumps the following:

- `ecdsa` v0.15
- `ed25519` v2
- `p256` v0.12
- `p384` v0.12
- `signature` v2