### PR TITLE
Bump elliptic curve dependencies; MSRV 1.65

### DIFF
--- a/.github/workflows/ring-compat.yml
+++ b/.github/workflows/ring-compat.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.60.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64ct"
@@ -59,15 +59,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.15.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
+checksum = "d1b0a1222f8072619e8a6b667a854020a03d363738303203c09468b3424a420a"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -119,26 +119,26 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf420a7ec85d98495b0c34aa4a58ca117f982ffbece111aeb545160148d7010"
+checksum = "be522bee13fa6d8059f4903a4084aa3bd50725e18150202f0238deb615cd6371"
 dependencies = [
  "signature",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
  "digest",
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
@@ -163,6 +163,7 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -178,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core",
@@ -224,16 +225,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "p256"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
+checksum = "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -242,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630a4a9b2618348ececfae61a4905f564b817063bf2d66cdfc2ced523fe1d2d4"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -253,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
 dependencies = [
  "der",
  "spki",
@@ -263,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b7e10b3a364b1c813238b1c9a749336cbe51fd4265cd99f57cf29302c90af7"
+checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
 dependencies = [
  "elliptic-curve",
 ]
@@ -314,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "ring-compat"
-version = "0.6.0"
+version = "0.7.0-pre"
 dependencies = [
  "aead",
  "digest",
@@ -322,7 +317,6 @@ dependencies = [
  "ed25519",
  "generic-array",
  "hex-literal",
- "opaque-debug",
  "p256",
  "p384",
  "pkcs8",
@@ -332,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
 dependencies = [
  "base16ct",
  "der",
@@ -361,9 +355,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-compat"
-version = "0.6.0"
+version = "0.7.0-pre"
 description = """
 Compatibility crate for using RustCrypto's traits with the cryptographic
 algorithm implementations from *ring*
@@ -13,21 +13,20 @@ repository = "https://github.com/RustCrypto/ring-compat"
 categories = ["cryptography", "no-std"]
 keywords = ["aead", "digest", "crypto", "ring", "signature"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 
 [dependencies]
 generic-array = { version = "0.14", default-features = false }
-opaque-debug = "0.3"
 ring = { version = "0.16", default-features = false }
 
 # optional dependencies
 aead = { version = "0.5", optional = true, default-features = false }
 digest = { version = "0.10", optional = true }
-ecdsa = { version = "0.15", optional = true, default-features = false }
+ecdsa = { version = "0.16", optional = true, default-features = false }
 ed25519 = { version = "2", optional = true, default-features = false }
-p256 = { version = "0.12", optional = true, default-features = false, features = ["ecdsa-core"] }
-p384 = { version = "0.12", optional = true, default-features = false, features = ["ecdsa-core"] }
-pkcs8 = { version = "0.9", optional = true, default-features = false }
+p256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa-core"] }
+p384 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa-core"] }
+pkcs8 = { version = "0.10", optional = true, default-features = false }
 signature = { version = "2", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Ring Version][ring-image]
 ![Rust Version][rustc-image]
 ![Apache2/MIT licensed][license-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Compatibility crate for using RustCrypto's [traits] with the cryptographic
 algorithm implementations from [*ring*].
@@ -15,7 +15,7 @@ algorithm implementations from [*ring*].
 
 ## Minimum Supported Rust Version
 
-**Rust 1.60** or higher.
+**Rust 1.65** or higher.
 
 In the future the minimum supported Rust version can be changed, but it will be
 done with a minor version bump.
@@ -41,14 +41,14 @@ dual licensed as above, without any additional terms or conditions.
 [crate-link]: https://crates.io/crates/ring-compat
 [docs-image]: https://docs.rs/ring-compat/badge.svg
 [docs-link]: https://docs.rs/ring-compat/
+[build-image]: https://github.com/RustCrypto/ring-compat/workflows/ring-compat/badge.svg?branch=master&event=push
+[build-link]: https://github.com/RustCrypto/ring-compat/actions
 [docs-link]: https://docs.rs/ring-compat
 [ring-image]: https://img.shields.io/badge/ring-0.16-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.60+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/260488-ring-compat
-[build-image]: https://github.com/RustCrypto/ring-compat/workflows/ring-compat/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/ring-compat/actions
 
 [//]: # (general links)
 

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,6 +1,6 @@
 //! Digest algorithms: SHA-1, SHA-256, SHA-384, SHA-512
 
-use core::mem;
+use core::{fmt, mem};
 use digest::{
     core_api::BlockSizeUser,
     generic_array::{typenum::*, GenericArray},
@@ -62,7 +62,11 @@ macro_rules! impl_digest {
             }
         }
 
-        opaque_debug::implement!($name);
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct(stringify!($name)).finish_non_exhaustive()
+            }
+        }
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,11 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/7f79a5e/img/ring-compat/logo-sq.png"
+)]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms)]
 
 //! # Features
 //!
@@ -11,14 +18,6 @@
 //!   - `ed25519`: Edwards Digital Signature Algorithm instantiated over Curve25519
 //!   - `p256`: ECDSA/NIST P-256
 //!   - `p384`: ECDSA/NIST P-384
-
-#![no_std]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(
-    html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/7f79a5e/img/ring-compat/logo-sq.png"
-)]
-#![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/src/signature/ecdsa/signing_key.rs
+++ b/src/signature/ecdsa/signing_key.rs
@@ -3,12 +3,12 @@
 use super::{CurveAlg, PrimeCurve, Signature, VerifyingKey};
 use crate::signature::{Error, Signer};
 use ::ecdsa::{
-    elliptic_curve::{sec1, FieldSize},
+    elliptic_curve::{sec1, FieldBytesSize},
     SignatureSize,
 };
 use core::marker::PhantomData;
 use generic_array::ArrayLength;
-use pkcs8::{DecodePrivateKey, PrivateKeyInfo};
+use pkcs8::DecodePrivateKey;
 use ring::{
     self,
     rand::SystemRandom,
@@ -50,7 +50,7 @@ where
     /// Get the [`VerifyingKey`] for this [`SigningKey`]
     pub fn verifying_key(&self) -> VerifyingKey<C>
     where
-        FieldSize<C>: sec1::ModulusSize,
+        FieldBytesSize<C>: sec1::ModulusSize,
     {
         VerifyingKey::new(self.keypair.public_key().as_ref()).unwrap()
     }
@@ -69,18 +69,6 @@ where
                 curve: PhantomData,
             })
             .map_err(|_| pkcs8::Error::KeyMalformed)
-    }
-}
-
-impl<C> TryFrom<PrivateKeyInfo<'_>> for SigningKey<C>
-where
-    C: PrimeCurve + CurveAlg,
-    SignatureSize<C>: ArrayLength<u8>,
-{
-    type Error = pkcs8::Error;
-
-    fn try_from(_: PrivateKeyInfo<'_>) -> Result<Self, pkcs8::Error> {
-        todo!()
     }
 }
 

--- a/src/signature/ecdsa/verifying_key.rs
+++ b/src/signature/ecdsa/verifying_key.rs
@@ -3,11 +3,11 @@
 use super::{CurveAlg, PrimeCurve, Signature};
 use crate::signature::{Error, Verifier};
 use ::ecdsa::{
-    elliptic_curve::{bigint::Encoding as _, sec1, FieldSize},
+    elliptic_curve::{sec1, FieldBytesSize},
     SignatureSize,
 };
 use core::convert::TryInto;
-use generic_array::ArrayLength;
+use generic_array::{typenum::Unsigned, ArrayLength};
 use ring::signature::UnparsedPublicKey;
 
 /// ECDSA verifying key. Generic over elliptic curves.
@@ -15,18 +15,18 @@ use ring::signature::UnparsedPublicKey;
 pub struct VerifyingKey<C>(sec1::EncodedPoint<C>)
 where
     C: PrimeCurve + CurveAlg,
-    FieldSize<C>: sec1::ModulusSize,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>;
 
 impl<C> VerifyingKey<C>
 where
     C: PrimeCurve + CurveAlg,
-    FieldSize<C>: sec1::ModulusSize,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     /// Initialize [`VerifyingKey`] from a SEC1-encoded public key
     pub fn new(bytes: &[u8]) -> Result<Self, Error> {
-        let point_result = if bytes.len() == C::UInt::BYTE_SIZE * 2 {
+        let point_result = if bytes.len() == C::FieldBytesSize::USIZE * 2 {
             Ok(sec1::EncodedPoint::<C>::from_untagged_bytes(
                 bytes.try_into().map_err(|_| Error::new())?,
             ))
@@ -46,7 +46,7 @@ where
 impl<C: PrimeCurve> Verifier<Signature<C>> for VerifyingKey<C>
 where
     C: PrimeCurve + CurveAlg,
-    FieldSize<C>: sec1::ModulusSize,
+    FieldBytesSize<C>: sec1::ModulusSize,
     SignatureSize<C>: ArrayLength<u8>,
 {
     fn verify(&self, msg: &[u8], sig: &Signature<C>) -> Result<(), Error> {

--- a/src/signature/ed25519.rs
+++ b/src/signature/ed25519.rs
@@ -6,7 +6,7 @@ pub use ed25519::Signature;
 
 use super::{Error, Signer, Verifier};
 use core::convert::TryInto;
-use pkcs8::{DecodePrivateKey, PrivateKeyInfo};
+use pkcs8::DecodePrivateKey;
 use ring::{
     self,
     signature::{Ed25519KeyPair, KeyPair, UnparsedPublicKey},
@@ -37,14 +37,6 @@ impl DecodePrivateKey for SigningKey {
         Ed25519KeyPair::from_pkcs8(pkcs8_bytes)
             .map(SigningKey)
             .map_err(|_| pkcs8::Error::KeyMalformed)
-    }
-}
-
-impl TryFrom<PrivateKeyInfo<'_>> for SigningKey {
-    type Error = pkcs8::Error;
-
-    fn try_from(_: PrivateKeyInfo<'_>) -> Result<Self, pkcs8::Error> {
-        todo!()
     }
 }
 


### PR DESCRIPTION
Bumps the following:

- `ecdsa` v0.16
- `elliptic-curve` v0.13
- `p256` v0.13
- `p384` v0.13
- `pkcs8` v0.10