### PR TITLE
v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0 (2023-03-19)
+### Added
+- `ed25518::SigningIey::from_bytes` ([#114])
+- `ed25519::SigningKey::generate` ([#115])
+- Impl `signature::Keypair` trait ([#116])
+
+### Changed
+- Bump elliptic curve dependencies; MSRV 1.65 ([#112])
+  - `ecdsa` v0.16
+  - `elliptic-curve` v0.13
+  - `p256` v0.13
+  - `p384` v0.13
+  - `pkcs8` v0.10
+- Rename `ed25519::SigningKey::from_seed` => `::from_slice` ([#114])
+- Rename `ed25519::VerifyingKey::new` => `::from_slice` ([#114])
+
+[#112]: https://github.com/RustCrypto/ring-compat/pull/112
+[#114]: https://github.com/RustCrypto/ring-compat/pull/114
+[#115]: https://github.com/RustCrypto/ring-compat/pull/115
+[#116]: https://github.com/RustCrypto/ring-compat/pull/116
+
 ## 0.6.0 (2023-01-21)
 ### Changed
 - Upgrade to `signature` v2-compatible dependencies ([#105])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "ring-compat"
-version = "0.7.0-pre"
+version = "0.7.0"
 dependencies = [
  "aead",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-compat"
-version = "0.7.0-pre"
+version = "0.7.0"
 description = """
 Compatibility crate for using RustCrypto's traits with the cryptographic
 algorithm implementations from *ring*
@@ -23,7 +23,7 @@ ring = { version = "0.16", default-features = false }
 aead = { version = "0.5", optional = true, default-features = false }
 digest = { version = "0.10", optional = true }
 ecdsa = { version = "0.16", optional = true, default-features = false }
-ed25519 = { version = "2", optional = true, default-features = false }
+ed25519 = { version = "2.2", optional = true, default-features = false }
 p256 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa-core"] }
 p384 = { version = "0.13", optional = true, default-features = false, features = ["ecdsa-core"] }
 pkcs8 = { version = "0.10", optional = true, default-features = false }


### PR DESCRIPTION
### Added
- `ed25518::SigningIey::from_bytes` ([#114])
- `ed25519::SigningKey::generate` ([#115])
- Impl `signature::Keypair` trait ([#116])

### Changed
- Bump elliptic curve dependencies; MSRV 1.65 ([#112])
  - `ecdsa` v0.16
  - `elliptic-curve` v0.13
  - `p256` v0.13
  - `p384` v0.13
  - `pkcs8` v0.10
- Rename `ed25519::SigningKey::from_seed` => `::from_slice` ([#114])
- Rename `ed25519::VerifyingKey::new` => `::from_slice` ([#114])

[#112]: https://github.com/RustCrypto/ring-compat/pull/112
[#114]: https://github.com/RustCrypto/ring-compat/pull/114
[#115]: https://github.com/RustCrypto/ring-compat/pull/115
[#116]: https://github.com/RustCrypto/ring-compat/pull/116